### PR TITLE
Build contributor showcase app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.next
+node_modules
+.env.local
+.vercel
+.agents_tmp
+npm-debug.log*
+.DS_Store
+tsconfig.tsbuildinfo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository Memory
+
+- Project uses a minimal Next.js App Router setup with TypeScript on Next.js 16.
+- Core commands: `npm install`, `npm run dev`, `npm run build`, `npm run typecheck`.
+- `app/page.tsx` is a server wrapper with `Suspense`; interactive UI lives in `app/showcase-page.tsx`.
+- Data routes live in `app/api/contributors/route.ts` and `app/api/svg/route.ts`.
+- Shared parsing, GitHub fetch, filtering, and SVG helpers live under `lib/`.
+- `GITHUB_TOKEN` is optional for public repos but recommended to avoid rate limits in local and Vercel environments.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,99 @@
 # Contributor Showcase
 
-Use this repo to showcase your contributors on your readme, or elsewhere.
+Contributor Showcase is a lightweight Next.js app that turns a public GitHub repository into a transparent SVG collage of circular contributor avatars.
+
+It is designed for two jobs:
+- previewing and tweaking a contributor wall in the browser
+- embedding the final SVG directly in a GitHub README
+
+## Features
+
+- Accepts `owner/repo` or full GitHub repository URLs
+- Fetches contributors server-side so GitHub tokens stay private
+- Filters bots automatically and supports manual exclude lists
+- Generates a transparent, README-safe SVG endpoint
+- Includes a small preview UI with copyable links, Markdown, and SVG download
+- Runs locally and deploys cleanly to Vercel
+
+## Local development
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Create `.env.local` if you want a GitHub token for higher API limits:
+
+   ```bash
+   GITHUB_TOKEN=your_github_token
+   ```
+
+   The app still works without a token for public repositories, but rate limits will be lower.
+
+3. Start the app:
+
+   ```bash
+   npm run dev
+   ```
+
+4. Open `http://localhost:3000`.
+
+## Scripts
+
+```bash
+npm run dev
+npm run build
+npm run start
+npm run typecheck
+```
+
+## README embed
+
+Once deployed, use the hosted SVG endpoint in Markdown:
+
+```md
+![OpenHands contributors](https://your-deployment.vercel.app/api/svg?repo=OpenHands/OpenHands)
+```
+
+Supported query parameters:
+
+- `repo`: required; `owner/repo` or full GitHub URL
+- `excludeBots`: optional; defaults to `true`
+- `exclude`: optional comma-separated GitHub logins
+- `limit`: optional avatar count limit, default `60`
+- `width`: optional SVG width, default `720`
+- `size`: optional avatar size, default `56`
+- `gap`: optional gap between avatars, default `8`
+
+Example:
+
+```md
+![Contributors](https://your-deployment.vercel.app/api/svg?repo=OpenHands/OpenHands&exclude=dependabot,renovate)
+```
+
+## API routes
+
+- `/api/contributors` returns normalized contributor data as JSON
+- `/api/svg` returns the transparent contributor collage as raw SVG
+
+Example JSON request:
+
+```text
+/api/contributors?repo=OpenHands/OpenHands&excludeBots=false
+```
+
+## Vercel deployment
+
+1. Import the repository into Vercel.
+2. Add `GITHUB_TOKEN` as an environment variable if you want higher GitHub API limits.
+3. Deploy.
+
+The same codebase is used for local development and production.
+
+## Notes on caching
+
+GitHub and external CDNs may cache remote README images. If you need fully predictable updates, you can also download the generated SVG from the app and commit it into your repository instead of relying on the live hosted image URL.
 
 ## License
 

--- a/app/api/contributors/route.ts
+++ b/app/api/contributors/route.ts
@@ -1,0 +1,58 @@
+import { filterContributors, normalizeContributors } from '@/lib/contributors';
+import { fetchGitHubContributors, GitHubApiError } from '@/lib/github';
+import { parseShowcaseQuery } from '@/lib/query';
+import { normalizeRepoInput } from '@/lib/repo';
+
+export const runtime = 'nodejs';
+
+function jsonResponse(body: unknown, status = 200) {
+  return Response.json(body, {
+    status,
+    headers: {
+      'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+    },
+  });
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+
+  try {
+    const query = parseShowcaseQuery(searchParams);
+    const repo = normalizeRepoInput(query.repoInput);
+    const rawContributors = await fetchGitHubContributors(repo.owner, repo.repo, query.limit);
+    const normalized = normalizeContributors(rawContributors);
+    const filtered = filterContributors(normalized, {
+      excludeBots: query.excludeBots,
+      excludeLogins: query.excludeLogins,
+    });
+
+    return jsonResponse({
+      repo,
+      options: {
+        excludeBots: query.excludeBots,
+        excludeLogins: query.excludeLogins,
+        limit: query.limit,
+        width: query.width,
+        size: query.size,
+        gap: query.gap,
+      },
+      stats: {
+        fetched: normalized.length,
+        returned: Math.min(filtered.length, query.limit),
+        filteredOut: Math.max(normalized.length - filtered.length, 0),
+      },
+      contributors: filtered.slice(0, query.limit),
+    });
+  } catch (error) {
+    if (error instanceof GitHubApiError) {
+      return jsonResponse({ error: error.message }, error.status);
+    }
+
+    if (error instanceof Error) {
+      return jsonResponse({ error: error.message }, 400);
+    }
+
+    return jsonResponse({ error: 'Unexpected error while loading contributors.' }, 500);
+  }
+}

--- a/app/api/svg/route.ts
+++ b/app/api/svg/route.ts
@@ -1,0 +1,65 @@
+import { buildContributorSvg } from '@/lib/svg';
+import { filterContributors, normalizeContributors } from '@/lib/contributors';
+import { fetchGitHubContributors, GitHubApiError } from '@/lib/github';
+import { parseShowcaseQuery } from '@/lib/query';
+import { normalizeRepoInput } from '@/lib/repo';
+
+export const runtime = 'nodejs';
+
+function svgResponse(body: string, status = 200) {
+  return new Response(body, {
+    status,
+    headers: {
+      'Content-Type': 'image/svg+xml; charset=utf-8',
+      'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+    },
+  });
+}
+
+function errorSvg(message: string): string {
+  const safeMessage = message.replace(/[<&>]/g, '');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="96" viewBox="0 0 720 96" role="img" aria-labelledby="title desc">
+  <title id="title">Contributor Showcase error</title>
+  <desc id="desc">${safeMessage}</desc>
+  <rect width="100%" height="100%" fill="transparent"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" fill="#ef4444">
+    ${safeMessage}
+  </text>
+</svg>`;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+
+  try {
+    const query = parseShowcaseQuery(searchParams);
+    const repo = normalizeRepoInput(query.repoInput);
+    const rawContributors = await fetchGitHubContributors(repo.owner, repo.repo, query.limit);
+    const normalized = normalizeContributors(rawContributors);
+    const contributors = filterContributors(normalized, {
+      excludeBots: query.excludeBots,
+      excludeLogins: query.excludeLogins,
+    }).slice(0, query.limit);
+
+    const svg = await buildContributorSvg(contributors, {
+      repoSlug: repo.slug,
+      width: query.width,
+      size: query.size,
+      gap: query.gap,
+    });
+
+    return svgResponse(svg);
+  } catch (error) {
+    if (error instanceof GitHubApiError) {
+      return svgResponse(errorSvg(error.message), error.status);
+    }
+
+    if (error instanceof Error) {
+      return svgResponse(errorSvg(error.message), 400);
+    }
+
+    return svgResponse(errorSvg('Unexpected error while generating the SVG.'), 500);
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,309 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #0b1120;
+  color: #e2e8f0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  background:
+    radial-gradient(circle at top, rgba(59, 130, 246, 0.22), transparent 35%),
+    linear-gradient(180deg, #020617 0%, #0f172a 50%, #020617 100%);
+}
+
+body {
+  color: #e2e8f0;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+.page-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0 72px;
+}
+
+.hero-card,
+.info-card,
+.preview-card {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 24px;
+  background: rgba(15, 23, 42, 0.78);
+  box-shadow: 0 24px 60px rgba(2, 6, 23, 0.38);
+  backdrop-filter: blur(18px);
+}
+
+.hero-card {
+  padding: 32px;
+  display: grid;
+  gap: 28px;
+}
+
+.hero-copy {
+  max-width: 720px;
+}
+
+.eyebrow {
+  display: inline-flex;
+  margin-bottom: 16px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.14);
+  color: #93c5fd;
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+}
+
+.hero-copy h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 5vw, 4rem);
+  line-height: 1.02;
+}
+
+.hero-copy p {
+  margin: 16px 0 0;
+  max-width: 60ch;
+  color: #cbd5e1;
+  font-size: 1.05rem;
+  line-height: 1.65;
+}
+
+.controls-grid,
+.info-grid,
+.preview-grid {
+  display: grid;
+  gap: 20px;
+}
+
+.controls-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.info-grid,
+.preview-grid {
+  margin-top: 24px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.field-group {
+  display: grid;
+  gap: 10px;
+}
+
+.field-span-2 {
+  grid-column: span 2;
+}
+
+.field-group span {
+  color: #cbd5e1;
+  font-size: 0.95rem;
+}
+
+.field-group input[type='text'],
+.field-group input[type='url'],
+.field-group input[type='search'],
+.field-group input {
+  width: 100%;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.92);
+  color: #f8fafc;
+  padding: 14px 16px;
+}
+
+.field-group input::placeholder {
+  color: #64748b;
+}
+
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 18px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.56);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.checkbox-row input {
+  width: 18px;
+  height: 18px;
+}
+
+.action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.action-row button,
+.secondary-button,
+.ghost-button {
+  border: 0;
+  border-radius: 14px;
+  padding: 12px 16px;
+  transition: transform 120ms ease, opacity 120ms ease, background 120ms ease;
+}
+
+.action-row button {
+  background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+  color: white;
+  font-weight: 600;
+}
+
+.secondary-button,
+.ghost-button {
+  background: rgba(148, 163, 184, 0.12);
+  color: #e2e8f0;
+}
+
+.action-row button:hover,
+.secondary-button:hover,
+.ghost-button:hover {
+  transform: translateY(-1px);
+  opacity: 0.96;
+}
+
+.info-card,
+.preview-card {
+  padding: 24px;
+}
+
+.section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.copy-message,
+.muted {
+  color: #94a3b8;
+  font-size: 0.92rem;
+}
+
+.snippet-block {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.54);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.snippet-block + .snippet-block {
+  margin-top: 12px;
+}
+
+.snippet-block code {
+  overflow-wrap: anywhere;
+  color: #bfdbfe;
+  line-height: 1.55;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.stats-grid div {
+  display: grid;
+  gap: 4px;
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.54);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.stats-grid strong {
+  font-size: 1.5rem;
+}
+
+.stats-grid span {
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.avatar-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.avatar-list img {
+  display: block;
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+}
+
+.error-text {
+  color: #fca5a5;
+  margin: 0;
+}
+
+.light-surface {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(241, 245, 249, 0.95));
+  color: #0f172a;
+}
+
+.dark-surface {
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.95), rgba(2, 6, 23, 0.96));
+}
+
+.preview-image {
+  width: 100%;
+  display: block;
+  border-radius: 18px;
+}
+
+@media (max-width: 860px) {
+  .controls-grid,
+  .info-grid,
+  .preview-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .field-span-2 {
+    grid-column: auto;
+  }
+
+  .page-shell {
+    width: min(100% - 24px, 1120px);
+    padding-top: 24px;
+  }
+
+  .hero-card,
+  .info-card,
+  .preview-card {
+    border-radius: 20px;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Contributor Showcase',
+  description: 'Generate lightweight contributor collages for GitHub READMEs.',
+};
+
+export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,24 @@
+import { Suspense } from 'react';
+import ShowcasePage from '@/app/showcase-page';
+
+function LoadingState() {
+  return (
+    <main className="page-shell">
+      <section className="hero-card">
+        <div className="hero-copy">
+          <span className="eyebrow">README-safe contributor collage</span>
+          <h1>Preparing your contributor preview…</h1>
+          <p className="muted">Loading the client-side controls.</p>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+export default function HomePage() {
+  return (
+    <Suspense fallback={<LoadingState />}>
+      <ShowcasePage />
+    </Suspense>
+  );
+}

--- a/app/showcase-page.tsx
+++ b/app/showcase-page.tsx
@@ -1,0 +1,307 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { buildQueryString, parseExcludeList } from '@/lib/query';
+
+type ContributorResponse = {
+  repo: {
+    owner: string;
+    repo: string;
+    slug: string;
+  };
+  stats: {
+    fetched: number;
+    returned: number;
+    filteredOut: number;
+  };
+  contributors: Array<{
+    login: string;
+    avatarUrl: string;
+    profileUrl: string;
+    contributions: number;
+  }>;
+  error?: string;
+};
+
+type FormState = {
+  repoInput: string;
+  excludeBots: boolean;
+  exclude: string;
+};
+
+const DEFAULT_STATE: FormState = {
+  repoInput: 'OpenHands/OpenHands',
+  excludeBots: true,
+  exclude: '',
+};
+
+function readFormState(searchParams: URLSearchParams): FormState {
+  return {
+    repoInput: searchParams.get('repo')?.trim() || DEFAULT_STATE.repoInput,
+    excludeBots: searchParams.get('excludeBots') !== 'false',
+    exclude: searchParams.get('exclude') || '',
+  };
+}
+
+export default function HomePage() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [origin, setOrigin] = useState('');
+  const [formState, setFormState] = useState<FormState>(DEFAULT_STATE);
+  const [appliedState, setAppliedState] = useState<FormState>(DEFAULT_STATE);
+  const [data, setData] = useState<ContributorResponse | null>(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [copyMessage, setCopyMessage] = useState('');
+
+  const searchParamString = searchParams.toString();
+  const currentState = useMemo(() => readFormState(new URLSearchParams(searchParamString)), [searchParamString]);
+
+  useEffect(() => {
+    setOrigin(window.location.origin);
+  }, []);
+
+  useEffect(() => {
+    setFormState(currentState);
+    setAppliedState(currentState);
+  }, [currentState]);
+
+  useEffect(() => {
+    const params = buildQueryString({
+      repoInput: appliedState.repoInput,
+      excludeBots: appliedState.excludeBots,
+      excludeLogins: parseExcludeList(appliedState.exclude),
+    });
+
+    const controller = new AbortController();
+    const requestPath = `/api/contributors?${params}`;
+
+    async function loadContributors() {
+      setLoading(true);
+      setError('');
+
+      try {
+        const response = await fetch(requestPath, { signal: controller.signal });
+        const payload = (await response.json()) as ContributorResponse & { error?: string };
+
+        if (!response.ok) {
+          throw new Error(payload.error || 'Unable to load contributors.');
+        }
+
+        setData(payload);
+      } catch (requestError) {
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        setData(null);
+        setError(requestError instanceof Error ? requestError.message : 'Unable to load contributors.');
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadContributors();
+
+    return () => controller.abort();
+  }, [appliedState]);
+
+  useEffect(() => {
+    if (!copyMessage) {
+      return undefined;
+    }
+
+    const timeout = window.setTimeout(() => setCopyMessage(''), 1800);
+    return () => window.clearTimeout(timeout);
+  }, [copyMessage]);
+
+  const queryString = useMemo(
+    () =>
+      buildQueryString({
+        repoInput: appliedState.repoInput,
+        excludeBots: appliedState.excludeBots,
+        excludeLogins: parseExcludeList(appliedState.exclude),
+      }),
+    [appliedState],
+  );
+
+  const svgPath = `/api/svg?${queryString}`;
+  const previewUrl = origin ? `${origin}${svgPath}` : svgPath;
+  const pageUrl = origin ? `${origin}${pathname}?${queryString}` : `${pathname}?${queryString}`;
+  const markdownSnippet = `![${appliedState.repoInput} contributors](${previewUrl})`;
+  const downloadName = `${appliedState.repoInput.replace(/[^a-z0-9-_]+/gi, '-').toLowerCase()}-contributors.svg`;
+
+  async function copyText(value: string, label: string) {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopyMessage(`${label} copied.`);
+    } catch {
+      setCopyMessage(`Unable to copy ${label.toLowerCase()}.`);
+    }
+  }
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const nextState = {
+      repoInput: formState.repoInput.trim() || DEFAULT_STATE.repoInput,
+      excludeBots: formState.excludeBots,
+      exclude: formState.exclude,
+    };
+
+    const params = buildQueryString({
+      repoInput: nextState.repoInput,
+      excludeBots: nextState.excludeBots,
+      excludeLogins: parseExcludeList(nextState.exclude),
+    });
+
+    router.replace(`${pathname}?${params}`);
+    setAppliedState(nextState);
+  }
+
+  return (
+    <main className="page-shell">
+      <section className="hero-card">
+        <div className="hero-copy">
+          <span className="eyebrow">README-safe contributor collage</span>
+          <h1>Turn any public GitHub repository into a transparent avatar wall.</h1>
+          <p>
+            Paste a repository, filter bots, preview the SVG, and copy a Markdown-ready image URL for your GitHub README.
+          </p>
+        </div>
+
+        <form className="controls-grid" onSubmit={handleSubmit}>
+          <label className="field-group field-span-2">
+            <span>Repository</span>
+            <input
+              name="repo"
+              placeholder="OpenHands/OpenHands or https://github.com/OpenHands/OpenHands"
+              value={formState.repoInput}
+              onChange={(event) => setFormState((current) => ({ ...current, repoInput: event.target.value }))}
+            />
+          </label>
+
+          <label className="field-group checkbox-row">
+            <input
+              type="checkbox"
+              checked={formState.excludeBots}
+              onChange={(event) => setFormState((current) => ({ ...current, excludeBots: event.target.checked }))}
+            />
+            <span>Exclude bots automatically</span>
+          </label>
+
+          <label className="field-group">
+            <span>Manual excludes</span>
+            <input
+              name="exclude"
+              placeholder="dependabot, renovate"
+              value={formState.exclude}
+              onChange={(event) => setFormState((current) => ({ ...current, exclude: event.target.value }))}
+            />
+          </label>
+
+          <div className="action-row field-span-2">
+            <button type="submit">Update preview</button>
+            <a className="secondary-button" href={svgPath} target="_blank" rel="noreferrer">
+              Open raw SVG
+            </a>
+            <a className="secondary-button" href={svgPath} download={downloadName}>
+              Download SVG
+            </a>
+          </div>
+        </form>
+      </section>
+
+      <section className="info-grid">
+        <article className="info-card">
+          <div className="section-heading">
+            <h2>Share</h2>
+            {copyMessage ? <span className="copy-message">{copyMessage}</span> : null}
+          </div>
+          <div className="snippet-block">
+            <span>Preview link</span>
+            <code>{pageUrl}</code>
+            <button type="button" className="ghost-button" onClick={() => void copyText(pageUrl, 'Preview link')}>
+              Copy link
+            </button>
+          </div>
+          <div className="snippet-block">
+            <span>Image endpoint</span>
+            <code>{previewUrl}</code>
+            <button type="button" className="ghost-button" onClick={() => void copyText(previewUrl, 'Image URL')}>
+              Copy image URL
+            </button>
+          </div>
+          <div className="snippet-block">
+            <span>README snippet</span>
+            <code>{markdownSnippet}</code>
+            <button type="button" className="ghost-button" onClick={() => void copyText(markdownSnippet, 'Markdown snippet')}>
+              Copy Markdown
+            </button>
+          </div>
+        </article>
+
+        <article className="info-card">
+          <div className="section-heading">
+            <h2>Dataset</h2>
+            {loading ? <span className="muted">Loading…</span> : null}
+          </div>
+          {error ? (
+            <p className="error-text">{error}</p>
+          ) : data ? (
+            <>
+              <div className="stats-grid">
+                <div>
+                  <strong>{data.stats.returned}</strong>
+                  <span>displayed</span>
+                </div>
+                <div>
+                  <strong>{data.stats.fetched}</strong>
+                  <span>fetched</span>
+                </div>
+                <div>
+                  <strong>{data.stats.filteredOut}</strong>
+                  <span>filtered out</span>
+                </div>
+              </div>
+              <p className="muted">
+                Showing contributors for <strong>{data.repo.slug}</strong>.
+              </p>
+              <div className="avatar-list" aria-label="Contributor list">
+                {data.contributors.slice(0, 18).map((contributor) => (
+                  <a key={contributor.login} href={contributor.profileUrl} target="_blank" rel="noreferrer" title={contributor.login}>
+                    <img src={contributor.avatarUrl} alt={contributor.login} width={36} height={36} />
+                  </a>
+                ))}
+              </div>
+            </>
+          ) : (
+            <p className="muted">Contributor data will appear here.</p>
+          )}
+        </article>
+      </section>
+
+      <section className="preview-grid">
+        <article className="preview-card light-surface">
+          <div className="section-heading">
+            <h2>Light preview</h2>
+            <span className="muted">Transparent SVG</span>
+          </div>
+          <img className="preview-image" src={svgPath} alt="Contributor collage preview on a light surface" />
+        </article>
+
+        <article className="preview-card dark-surface">
+          <div className="section-heading">
+            <h2>Dark preview</h2>
+            <span className="muted">Same image endpoint</span>
+          </div>
+          <img className="preview-image" src={svgPath} alt="Contributor collage preview on a dark surface" />
+        </article>
+      </section>
+    </main>
+  );
+}

--- a/lib/contributors.ts
+++ b/lib/contributors.ts
@@ -1,0 +1,54 @@
+import type { Contributor, RawGitHubContributor } from '@/lib/types';
+
+function isLikelyBot(login: string, type?: string): boolean {
+  if (type === 'Bot') {
+    return true;
+  }
+
+  const normalized = login.toLowerCase();
+
+  return (
+    normalized.endsWith('[bot]') ||
+    normalized === 'dependabot' ||
+    normalized.startsWith('dependabot') ||
+    normalized === 'renovate' ||
+    normalized === 'github-actions' ||
+    /(?:^|[-_])bot(?:$|[-_])/i.test(normalized)
+  );
+}
+
+export function normalizeContributors(rawContributors: RawGitHubContributor[]): Contributor[] {
+  return rawContributors
+    .filter((contributor): contributor is Required<Pick<RawGitHubContributor, 'login' | 'avatar_url' | 'html_url'>> & RawGitHubContributor => {
+      return Boolean(contributor.login && contributor.avatar_url && contributor.html_url);
+    })
+    .map((contributor) => ({
+      login: contributor.login,
+      avatarUrl: contributor.avatar_url,
+      profileUrl: contributor.html_url,
+      contributions: contributor.contributions ?? 0,
+      isBot: isLikelyBot(contributor.login, contributor.type),
+    }));
+}
+
+export function filterContributors(
+  contributors: Contributor[],
+  options: {
+    excludeBots: boolean;
+    excludeLogins: string[];
+  },
+): Contributor[] {
+  const excluded = new Set(options.excludeLogins.map((login) => login.toLowerCase()));
+
+  return contributors.filter((contributor) => {
+    if (excluded.has(contributor.login.toLowerCase())) {
+      return false;
+    }
+
+    if (options.excludeBots && contributor.isBot) {
+      return false;
+    }
+
+    return true;
+  });
+}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,0 +1,71 @@
+import type { RawGitHubContributor } from '@/lib/types';
+
+const GITHUB_API_BASE_URL = 'https://api.github.com';
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+const MAX_PAGES = 10;
+
+export class GitHubApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'GitHubApiError';
+    this.status = status;
+  }
+}
+
+function buildHeaders(): HeadersInit {
+  return {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'contributor-showcase',
+    ...(GITHUB_TOKEN ? { Authorization: `Bearer ${GITHUB_TOKEN}` } : {}),
+  };
+}
+
+export async function fetchGitHubContributors(
+  owner: string,
+  repo: string,
+  targetCount: number,
+): Promise<RawGitHubContributor[]> {
+  const contributors: RawGitHubContributor[] = [];
+  const maxResults = Math.max(100, Math.min(targetCount * 3, 500));
+
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const response = await fetch(
+      `${GITHUB_API_BASE_URL}/repos/${owner}/${repo}/contributors?per_page=100&page=${page}`,
+      {
+        headers: buildHeaders(),
+        next: { revalidate: 3600 },
+      },
+    );
+
+    if (!response.ok) {
+      let message = `GitHub returned ${response.status}.`;
+
+      try {
+        const body = (await response.json()) as { message?: string };
+        if (body.message) {
+          message = body.message;
+        }
+      } catch {
+        // Ignore JSON parsing failures for GitHub errors.
+      }
+
+      throw new GitHubApiError(message, response.status);
+    }
+
+    const pageContributors = (await response.json()) as RawGitHubContributor[];
+
+    if (!Array.isArray(pageContributors) || pageContributors.length === 0) {
+      break;
+    }
+
+    contributors.push(...pageContributors);
+
+    if (pageContributors.length < 100 || contributors.length >= maxResults) {
+      break;
+    }
+  }
+
+  return contributors;
+}

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -1,0 +1,87 @@
+import type { ShowcaseQuery } from '@/lib/types';
+
+const DEFAULT_REPO = 'OpenHands/OpenHands';
+const DEFAULT_LIMIT = 60;
+const DEFAULT_WIDTH = 720;
+const DEFAULT_SIZE = 56;
+const DEFAULT_GAP = 8;
+
+type SearchParamReader = {
+  get(name: string): string | null;
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function parseBoolean(value: string | null, fallback: boolean): boolean {
+  if (value === null) {
+    return fallback;
+  }
+
+  if (/^(1|true|yes|on)$/i.test(value)) {
+    return true;
+  }
+
+  if (/^(0|false|no|off)$/i.test(value)) {
+    return false;
+  }
+
+  return fallback;
+}
+
+function parseInteger(value: string | null, fallback: number, min: number, max: number): number {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  return clamp(parsed, min, max);
+}
+
+export function parseExcludeList(value: string | null): string[] {
+  if (!value) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      value
+        .split(',')
+        .map((item) => item.trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  );
+}
+
+export function parseShowcaseQuery(searchParams: SearchParamReader): ShowcaseQuery {
+  return {
+    repoInput: searchParams.get('repo')?.trim() || DEFAULT_REPO,
+    excludeBots: parseBoolean(searchParams.get('excludeBots'), true),
+    excludeLogins: parseExcludeList(searchParams.get('exclude')),
+    limit: parseInteger(searchParams.get('limit'), DEFAULT_LIMIT, 1, 200),
+    width: parseInteger(searchParams.get('width'), DEFAULT_WIDTH, 160, 1600),
+    size: parseInteger(searchParams.get('size'), DEFAULT_SIZE, 24, 128),
+    gap: parseInteger(searchParams.get('gap'), DEFAULT_GAP, 0, 48),
+  };
+}
+
+export function buildQueryString(query: Pick<ShowcaseQuery, 'repoInput' | 'excludeBots' | 'excludeLogins'>): string {
+  const params = new URLSearchParams();
+  params.set('repo', query.repoInput.trim() || DEFAULT_REPO);
+
+  if (!query.excludeBots) {
+    params.set('excludeBots', 'false');
+  }
+
+  if (query.excludeLogins.length > 0) {
+    params.set('exclude', query.excludeLogins.join(','));
+  }
+
+  return params.toString();
+}

--- a/lib/repo.ts
+++ b/lib/repo.ts
@@ -1,0 +1,59 @@
+import type { NormalizedRepo } from '@/lib/types';
+
+const GITHUB_HOSTS = new Set(['github.com', 'www.github.com']);
+
+function cleanRepoSegment(value: string): string {
+  return value.replace(/\.git$/i, '').trim();
+}
+
+export function normalizeRepoInput(input: string): NormalizedRepo {
+  const value = input.trim();
+
+  if (!value) {
+    throw new Error('Provide a GitHub repository in owner/repo format or as a GitHub URL.');
+  }
+
+  if (value.startsWith('http://') || value.startsWith('https://')) {
+    let url: URL;
+
+    try {
+      url = new URL(value);
+    } catch {
+      throw new Error('The repository URL is not valid.');
+    }
+
+    if (!GITHUB_HOSTS.has(url.hostname.toLowerCase())) {
+      throw new Error('Only github.com repository URLs are supported.');
+    }
+
+    const segments = url.pathname.split('/').filter(Boolean);
+
+    if (segments.length < 2) {
+      throw new Error('GitHub repository URLs must include both an owner and a repository name.');
+    }
+
+    const owner = segments[0]?.trim();
+    const repo = cleanRepoSegment(segments[1] ?? '');
+
+    if (!owner || !repo) {
+      throw new Error('The repository URL is missing an owner or repository name.');
+    }
+
+    return { owner, repo, slug: `${owner}/${repo}` };
+  }
+
+  const match = value.match(/^([^/\s]+)\/([^/\s]+)$/);
+
+  if (!match) {
+    throw new Error('Use owner/repo format or a full GitHub repository URL.');
+  }
+
+  const owner = match[1]?.trim();
+  const repo = cleanRepoSegment(match[2] ?? '');
+
+  if (!owner || !repo) {
+    throw new Error('The repository input is missing an owner or repository name.');
+  }
+
+  return { owner, repo, slug: `${owner}/${repo}` };
+}

--- a/lib/svg.ts
+++ b/lib/svg.ts
@@ -1,0 +1,84 @@
+import type { Contributor, SvgLayoutOptions } from '@/lib/types';
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function toDataUri(contentType: string, bytes: ArrayBuffer): string {
+  return `data:${contentType};base64,${Buffer.from(bytes).toString('base64')}`;
+}
+
+async function inlineAvatar(avatarUrl: string, size: number): Promise<string> {
+  const sizedUrl = `${avatarUrl}${avatarUrl.includes('?') ? '&' : '?'}s=${Math.max(size * 2, 64)}`;
+
+  try {
+    const response = await fetch(sizedUrl, {
+      next: { revalidate: 86400 },
+    });
+
+    if (!response.ok) {
+      return sizedUrl;
+    }
+
+    const contentType = response.headers.get('content-type') || 'image/png';
+    const bytes = await response.arrayBuffer();
+    return toDataUri(contentType, bytes);
+  } catch {
+    return sizedUrl;
+  }
+}
+
+export async function buildContributorSvg(
+  contributors: Contributor[],
+  options: SvgLayoutOptions,
+): Promise<string> {
+  if (contributors.length === 0) {
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${options.width}" height="88" viewBox="0 0 ${options.width} 88" role="img" aria-labelledby="title desc">
+  <title id="title">No contributors available for ${escapeXml(options.repoSlug)}</title>
+  <desc id="desc">No contributors were returned after applying the selected filters.</desc>
+  <rect width="100%" height="100%" fill="transparent"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" fill="#6b7280">
+    No contributors matched the current filters.
+  </text>
+</svg>`;
+  }
+
+  const columns = Math.max(1, Math.floor((options.width + options.gap) / (options.size + options.gap)));
+  const rows = Math.ceil(contributors.length / columns);
+  const height = rows * options.size + Math.max(0, rows - 1) * options.gap;
+  const avatars = await Promise.all(contributors.map((contributor) => inlineAvatar(contributor.avatarUrl, options.size)));
+
+  const content = contributors
+    .map((contributor, index) => {
+      const column = index % columns;
+      const row = Math.floor(index / columns);
+      const x = column * (options.size + options.gap);
+      const y = row * (options.size + options.gap);
+      const clipId = `clip-${index}`;
+      const label = `${contributor.login} · ${contributor.contributions} contribution${contributor.contributions === 1 ? '' : 's'}`;
+
+      return `
+  <g>
+    <title>${escapeXml(label)}</title>
+    <clipPath id="${clipId}">
+      <circle cx="${x + options.size / 2}" cy="${y + options.size / 2}" r="${options.size / 2}" />
+    </clipPath>
+    <image href="${avatars[index]}" x="${x}" y="${y}" width="${options.size}" height="${options.size}" clip-path="url(#${clipId})" preserveAspectRatio="xMidYMid slice" />
+  </g>`;
+    })
+    .join('');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${options.width}" height="${height}" viewBox="0 0 ${options.width} ${height}" role="img" aria-labelledby="title desc">
+  <title id="title">Contributors for ${escapeXml(options.repoSlug)}</title>
+  <desc id="desc">A transparent wall of circular contributor avatars.</desc>
+  <rect width="100%" height="100%" fill="transparent"/>
+${content}
+</svg>`;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,38 @@
+export type RawGitHubContributor = {
+  login?: string;
+  avatar_url?: string;
+  html_url?: string;
+  contributions?: number;
+  type?: string;
+};
+
+export type Contributor = {
+  login: string;
+  avatarUrl: string;
+  profileUrl: string;
+  contributions: number;
+  isBot: boolean;
+};
+
+export type NormalizedRepo = {
+  owner: string;
+  repo: string;
+  slug: string;
+};
+
+export type ShowcaseQuery = {
+  repoInput: string;
+  excludeBots: boolean;
+  excludeLogins: string[];
+  limit: number;
+  width: number;
+  size: number;
+  gap: number;
+};
+
+export type SvgLayoutOptions = {
+  repoSlug: string;
+  width: number;
+  size: number;
+  gap: number;
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,976 @@
+{
+  "name": "contributor-showcase",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "contributor-showcase",
+      "version": "0.1.0",
+      "dependencies": {
+        "next": "16.2.1",
+        "react": "19.0.0",
+        "react-dom": "19.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "22.13.14",
+        "@types/react": "19.0.10",
+        "@types/react-dom": "19.0.4",
+        "typescript": "5.8.2"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.1.tgz",
+      "integrity": "sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.1.tgz",
+      "integrity": "sha512-BwZ8w8YTaSEr2HIuXLMLxIdElNMPvY9fLqb20LX9A9OMGtJilhHLbCL3ggyd0TwjmMcTxi0XXt+ur1vWUoxj2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.1.tgz",
+      "integrity": "sha512-/vrcE6iQSJq3uL3VGVHiXeaKbn8Es10DGTGRJnRZlkNQQk3kaNtAJg8Y6xuAlrx/6INKVjkfi5rY0iEXorZ6uA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.1.tgz",
+      "integrity": "sha512-uLn+0BK+C31LTVbQ/QU+UaVrV0rRSJQ8RfniQAHPghDdgE+SlroYqcmFnO5iNjNfVWCyKZHYrs3Nl0mUzWxbBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.1.tgz",
+      "integrity": "sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.1.tgz",
+      "integrity": "sha512-HQm7SrHRELJ30T1TSmT706IWovFFSRGxfgUkyWJZF/RKBMdbdRWJuFrcpDdE5vy9UXjFOx6L3mRdqH04Mmx0hg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.1.tgz",
+      "integrity": "sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.1.tgz",
+      "integrity": "sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.1.tgz",
+      "integrity": "sha512-qvU+3a39Hay+ieIztkGSbF7+mccbbg1Tk25hc4JDylf8IHjYmY/Zm64Qq1602yPyQqvie+vf5T/uPwNxDNIoeg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.13.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.14.tgz",
+      "integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
+      "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.0.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.4.tgz",
+      "integrity": "sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.11",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.11.tgz",
+      "integrity": "sha512-DAKrHphkJyiGuau/cFieRYhcTFeK/lBuD++C7cZ6KZHbMhBrisoi+EvhQ5RZrIfV5qwsW8kgQ07JIC+MDJRAhg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001781",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
+      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.1.tgz",
+      "integrity": "sha512-VaChzNL7o9rbfdt60HUj8tev4m6d7iC1igAy157526+cJlXOQu5LzsBXNT+xaJnTP/k+utSX5vMv7m0G+zKH+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.2.1",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.2.1",
+        "@next/swc-darwin-x64": "16.2.1",
+        "@next/swc-linux-arm64-gnu": "16.2.1",
+        "@next/swc-linux-arm64-musl": "16.2.1",
+        "@next/swc-linux-x64-gnu": "16.2.1",
+        "@next/swc-linux-x64-musl": "16.2.1",
+        "@next/swc-win32-arm64-msvc": "16.2.1",
+        "@next/swc-win32-x64-msvc": "16.2.1",
+        "sharp": "^0.34.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.25.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "contributor-showcase",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "16.2.1",
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "22.13.14",
+    "@types/react": "19.0.10",
+    "@types/react-dom": "19.0.4",
+    "typescript": "5.8.2"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold a lightweight Next.js 16 App Router app for contributor collages
- add server-side GitHub contributor fetching, repo parsing, filtering, and SVG generation routes
- build a preview UI with README embed helpers and document local/Vercel usage

## Testing
- npm run typecheck
- npm run build
- verified `/api/contributors` and `/api/svg` responses locally
