### PR TITLE
feat: adjustable SVG block with height constraint and optimized width

### DIFF
--- a/app/api/svg/route.ts
+++ b/app/api/svg/route.ts
@@ -47,6 +47,7 @@ export async function GET(request: Request) {
     const svg = await buildContributorSvg(contributors, {
       repoSlug: repo.slug,
       width: query.width,
+      height: query.height,
       size: query.size,
       gap: query.gap,
     });

--- a/app/globals.css
+++ b/app/globals.css
@@ -285,6 +285,42 @@ button {
   border-radius: 18px;
 }
 
+.layout-fieldset {
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 16px;
+  padding: 18px;
+  margin: 0;
+  background: rgba(15, 23, 42, 0.36);
+}
+
+.layout-fieldset legend {
+  padding: 0 8px;
+  color: #cbd5e1;
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.layout-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.layout-grid .field-group {
+  gap: 6px;
+}
+
+.layout-grid input {
+  padding: 10px 12px;
+  border-radius: 12px;
+}
+
+.layout-hint {
+  margin: 12px 0 0;
+  color: #94a3b8;
+  font-size: 0.85rem;
+}
+
 @media (max-width: 860px) {
   .controls-grid,
   .info-grid,
@@ -305,5 +341,9 @@ button {
   .info-card,
   .preview-card {
     border-radius: 20px;
+  }
+
+  .layout-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/app/showcase-page.tsx
+++ b/app/showcase-page.tsx
@@ -28,19 +28,37 @@ type FormState = {
   repoInput: string;
   excludeBots: boolean;
   exclude: string;
+  width: string;
+  height: string;
+  size: string;
+  gap: string;
 };
 
 const DEFAULT_STATE: FormState = {
   repoInput: 'OpenHands/OpenHands',
   excludeBots: true,
   exclude: '',
+  width: '830',
+  height: '',
+  size: '56',
+  gap: '8',
 };
+
+function parseOptionalInt(value: string | null, fallback: string): string {
+  if (!value) return fallback;
+  const num = Number.parseInt(value, 10);
+  return Number.isFinite(num) ? String(num) : fallback;
+}
 
 function readFormState(searchParams: URLSearchParams): FormState {
   return {
     repoInput: searchParams.get('repo')?.trim() || DEFAULT_STATE.repoInput,
     excludeBots: searchParams.get('excludeBots') !== 'false',
     exclude: searchParams.get('exclude') || '',
+    width: parseOptionalInt(searchParams.get('width'), DEFAULT_STATE.width),
+    height: searchParams.get('height') || '',
+    size: parseOptionalInt(searchParams.get('size'), DEFAULT_STATE.size),
+    gap: parseOptionalInt(searchParams.get('gap'), DEFAULT_STATE.gap),
   };
 }
 
@@ -125,6 +143,10 @@ export default function HomePage() {
         repoInput: appliedState.repoInput,
         excludeBots: appliedState.excludeBots,
         excludeLogins: parseExcludeList(appliedState.exclude),
+        width: appliedState.width ? Number.parseInt(appliedState.width, 10) : null,
+        height: appliedState.height ? Number.parseInt(appliedState.height, 10) : null,
+        size: appliedState.size ? Number.parseInt(appliedState.size, 10) : null,
+        gap: appliedState.gap ? Number.parseInt(appliedState.gap, 10) : null,
       }),
     [appliedState],
   );
@@ -147,16 +169,24 @@ export default function HomePage() {
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    const nextState = {
+    const nextState: FormState = {
       repoInput: formState.repoInput.trim() || DEFAULT_STATE.repoInput,
       excludeBots: formState.excludeBots,
       exclude: formState.exclude,
+      width: formState.width || DEFAULT_STATE.width,
+      height: formState.height,
+      size: formState.size || DEFAULT_STATE.size,
+      gap: formState.gap || DEFAULT_STATE.gap,
     };
 
     const params = buildQueryString({
       repoInput: nextState.repoInput,
       excludeBots: nextState.excludeBots,
       excludeLogins: parseExcludeList(nextState.exclude),
+      width: nextState.width ? Number.parseInt(nextState.width, 10) : null,
+      height: nextState.height ? Number.parseInt(nextState.height, 10) : null,
+      size: nextState.size ? Number.parseInt(nextState.size, 10) : null,
+      gap: nextState.gap ? Number.parseInt(nextState.gap, 10) : null,
     });
 
     router.replace(`${pathname}?${params}`);
@@ -203,6 +233,64 @@ export default function HomePage() {
               onChange={(event) => setFormState((current) => ({ ...current, exclude: event.target.value }))}
             />
           </label>
+
+          <fieldset className="field-group field-span-2 layout-fieldset">
+            <legend>Layout options</legend>
+            <div className="layout-grid">
+              <label className="field-group">
+                <span>Width (px)</span>
+                <input
+                  type="number"
+                  name="width"
+                  min="160"
+                  max="1600"
+                  placeholder="830"
+                  value={formState.width}
+                  onChange={(event) => setFormState((current) => ({ ...current, width: event.target.value }))}
+                />
+              </label>
+
+              <label className="field-group">
+                <span>Max height (px)</span>
+                <input
+                  type="number"
+                  name="height"
+                  min="16"
+                  max="4000"
+                  placeholder="Auto"
+                  value={formState.height}
+                  onChange={(event) => setFormState((current) => ({ ...current, height: event.target.value }))}
+                />
+              </label>
+
+              <label className="field-group">
+                <span>Avatar size (px)</span>
+                <input
+                  type="number"
+                  name="size"
+                  min="16"
+                  max="128"
+                  placeholder="56"
+                  value={formState.size}
+                  onChange={(event) => setFormState((current) => ({ ...current, size: event.target.value }))}
+                />
+              </label>
+
+              <label className="field-group">
+                <span>Gap (px)</span>
+                <input
+                  type="number"
+                  name="gap"
+                  min="0"
+                  max="48"
+                  placeholder="8"
+                  value={formState.gap}
+                  onChange={(event) => setFormState((current) => ({ ...current, gap: event.target.value }))}
+                />
+              </label>
+            </div>
+            <p className="layout-hint">Set max height to constrain the SVG. Avatars shrink automatically to fit.</p>
+          </fieldset>
 
           <div className="action-row field-span-2">
             <button type="submit">Update preview</button>

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -1,10 +1,12 @@
 import type { ShowcaseQuery } from '@/lib/types';
 
 const DEFAULT_REPO = 'OpenHands/OpenHands';
-const DEFAULT_WIDTH = 720;
+const DEFAULT_WIDTH = 830;
 const DEFAULT_SIZE = 56;
 const DEFAULT_GAP = 8;
 const MAX_LIMIT = 100000;
+const MIN_SIZE = 16;
+const MAX_HEIGHT = 4000;
 
 type SearchParamReader = {
   get(name: string): string | null;
@@ -58,6 +60,20 @@ function parseLimit(value: string | null): number | null {
   return clamp(parsed, 1, MAX_LIMIT);
 }
 
+function parseHeight(value: string | null): number | null {
+  if (!value || /^(auto|none)$/i.test(value)) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+
+  if (!Number.isFinite(parsed) || parsed < MIN_SIZE) {
+    return null;
+  }
+
+  return Math.min(parsed, MAX_HEIGHT);
+}
+
 export function parseExcludeList(value: string | null): string[] {
   if (!value) {
     return [];
@@ -80,7 +96,8 @@ export function parseShowcaseQuery(searchParams: SearchParamReader): ShowcaseQue
     excludeLogins: parseExcludeList(searchParams.get('exclude')),
     limit: parseLimit(searchParams.get('limit')),
     width: parseInteger(searchParams.get('width'), DEFAULT_WIDTH, 160, 1600),
-    size: parseInteger(searchParams.get('size'), DEFAULT_SIZE, 24, 128),
+    height: parseHeight(searchParams.get('height')),
+    size: parseInteger(searchParams.get('size'), DEFAULT_SIZE, MIN_SIZE, 128),
     gap: parseInteger(searchParams.get('gap'), DEFAULT_GAP, 0, 48),
   };
 }

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -102,7 +102,14 @@ export function parseShowcaseQuery(searchParams: SearchParamReader): ShowcaseQue
   };
 }
 
-export function buildQueryString(query: Pick<ShowcaseQuery, 'repoInput' | 'excludeBots' | 'excludeLogins'>): string {
+export type BuildQueryOptions = Pick<ShowcaseQuery, 'repoInput' | 'excludeBots' | 'excludeLogins'> & {
+  width?: number | null;
+  height?: number | null;
+  size?: number | null;
+  gap?: number | null;
+};
+
+export function buildQueryString(query: BuildQueryOptions): string {
   const params = new URLSearchParams();
   params.set('repo', query.repoInput.trim() || DEFAULT_REPO);
 
@@ -112,6 +119,22 @@ export function buildQueryString(query: Pick<ShowcaseQuery, 'repoInput' | 'exclu
 
   if (query.excludeLogins.length > 0) {
     params.set('exclude', query.excludeLogins.join(','));
+  }
+
+  if (query.width != null && query.width !== DEFAULT_WIDTH) {
+    params.set('width', String(query.width));
+  }
+
+  if (query.height != null) {
+    params.set('height', String(query.height));
+  }
+
+  if (query.size != null && query.size !== DEFAULT_SIZE) {
+    params.set('size', String(query.size));
+  }
+
+  if (query.gap != null && query.gap !== DEFAULT_GAP) {
+    params.set('gap', String(query.gap));
   }
 
   return params.toString();

--- a/lib/svg.ts
+++ b/lib/svg.ts
@@ -1,5 +1,7 @@
 import type { Contributor, SvgLayoutOptions } from '@/lib/types';
 
+const MIN_AVATAR_SIZE = 16;
+
 function escapeXml(value: string): string {
   return value
     .replaceAll('&', '&amp;')
@@ -33,10 +35,74 @@ async function inlineAvatar(avatarUrl: string, size: number): Promise<string> {
   }
 }
 
+type LayoutResult = {
+  size: number;
+  columns: number;
+  rows: number;
+  finalHeight: number;
+};
+
+export function calculateLayout(
+  contributorCount: number,
+  width: number,
+  height: number | null,
+  preferredSize: number,
+  gap: number,
+): LayoutResult {
+  if (contributorCount === 0) {
+    return { size: preferredSize, columns: 1, rows: 0, finalHeight: 88 };
+  }
+
+  const calcGrid = (size: number) => {
+    const columns = Math.max(1, Math.floor((width + gap) / (size + gap)));
+    const rows = Math.ceil(contributorCount / columns);
+    const gridHeight = rows * size + Math.max(0, rows - 1) * gap;
+    return { columns, rows, gridHeight };
+  };
+
+  if (height === null) {
+    const { columns, rows, gridHeight } = calcGrid(preferredSize);
+    return { size: preferredSize, columns, rows, finalHeight: gridHeight };
+  }
+
+  let { columns, rows, gridHeight } = calcGrid(preferredSize);
+
+  if (gridHeight <= height) {
+    return { size: preferredSize, columns, rows, finalHeight: gridHeight };
+  }
+
+  let low = MIN_AVATAR_SIZE;
+  let high = preferredSize;
+  let bestSize = MIN_AVATAR_SIZE;
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const { gridHeight: testHeight } = calcGrid(mid);
+
+    if (testHeight <= height) {
+      bestSize = mid;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  const result = calcGrid(bestSize);
+  return { size: bestSize, columns: result.columns, rows: result.rows, finalHeight: Math.min(result.gridHeight, height) };
+}
+
 export async function buildContributorSvg(
   contributors: Contributor[],
   options: SvgLayoutOptions,
 ): Promise<string> {
+  const layout = calculateLayout(
+    contributors.length,
+    options.width,
+    options.height,
+    options.size,
+    options.gap,
+  );
+
   if (contributors.length === 0) {
     return `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="${options.width}" height="88" viewBox="0 0 ${options.width} 88" role="img" aria-labelledby="title desc">
@@ -49,17 +115,15 @@ export async function buildContributorSvg(
 </svg>`;
   }
 
-  const columns = Math.max(1, Math.floor((options.width + options.gap) / (options.size + options.gap)));
-  const rows = Math.ceil(contributors.length / columns);
-  const height = rows * options.size + Math.max(0, rows - 1) * options.gap;
-  const avatars = await Promise.all(contributors.map((contributor) => inlineAvatar(contributor.avatarUrl, options.size)));
+  const { size, columns, finalHeight: height } = layout;
+  const avatars = await Promise.all(contributors.map((contributor) => inlineAvatar(contributor.avatarUrl, size)));
 
   const content = contributors
     .map((contributor, index) => {
       const column = index % columns;
       const row = Math.floor(index / columns);
-      const x = column * (options.size + options.gap);
-      const y = row * (options.size + options.gap);
+      const x = column * (size + options.gap);
+      const y = row * (size + options.gap);
       const clipId = `clip-${index}`;
       const label = `${contributor.login} · ${contributor.contributions} contribution${contributor.contributions === 1 ? '' : 's'}`;
 
@@ -67,9 +131,9 @@ export async function buildContributorSvg(
   <g>
     <title>${escapeXml(label)}</title>
     <clipPath id="${clipId}">
-      <circle cx="${x + options.size / 2}" cy="${y + options.size / 2}" r="${options.size / 2}" />
+      <circle cx="${x + size / 2}" cy="${y + size / 2}" r="${size / 2}" />
     </clipPath>
-    <image href="${avatars[index]}" x="${x}" y="${y}" width="${options.size}" height="${options.size}" clip-path="url(#${clipId})" preserveAspectRatio="xMidYMid slice" />
+    <image href="${avatars[index]}" x="${x}" y="${y}" width="${size}" height="${size}" clip-path="url(#${clipId})" preserveAspectRatio="xMidYMid slice" />
   </g>`;
     })
     .join('');

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -26,6 +26,7 @@ export type ShowcaseQuery = {
   excludeLogins: string[];
   limit: number | null;
   width: number;
+  height: number | null;
   size: number;
   gap: number;
 };
@@ -33,6 +34,7 @@ export type ShowcaseQuery = {
 export type SvgLayoutOptions = {
   repoSlug: string;
   width: number;
+  height: number | null;
   size: number;
   gap: number;
 };

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tests/showcase-routes.test.ts
+++ b/tests/showcase-routes.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
 import { GET as getContributors } from '@/app/api/contributors/route';
 import { GET as getSvg } from '@/app/api/svg/route';
+import { calculateLayout } from '@/lib/svg';
 
 type RawContributor = {
   login: string;
@@ -110,5 +111,69 @@ describe('showcase routes', () => {
     assert.match(svg, /user-205 · 205 contributions/);
     assert.equal(requests.getGithubRequests(), 3);
     assert.equal(requests.getAvatarRequests(), 205);
+  });
+
+  it('shrinks avatar size when height constraint is set', async () => {
+    const contributors = Array.from({ length: 100 }, (_, index) => createContributor(index + 1));
+    installFetchMock(contributors);
+
+    const response = await getSvg(new Request('http://localhost/api/svg?repo=owner/repo&height=100'));
+    const svg = await response.text();
+
+    assert.equal(response.status, 200);
+    const widthMatch = svg.match(/width="(\d+)"/);
+    const heightMatch = svg.match(/height="(\d+)"/);
+    assert.ok(widthMatch, 'SVG should have width attribute');
+    assert.ok(heightMatch, 'SVG should have height attribute');
+    const svgHeight = Number.parseInt(heightMatch[1], 10);
+    assert.ok(svgHeight <= 100, `SVG height ${svgHeight} should be <= 100`);
+    assert.equal((svg.match(/<image /g) ?? []).length, 100);
+  });
+
+  it('uses default width of 830 when width is not specified', async () => {
+    const contributors = Array.from({ length: 10 }, (_, index) => createContributor(index + 1));
+    installFetchMock(contributors);
+
+    const response = await getSvg(new Request('http://localhost/api/svg?repo=owner/repo'));
+    const svg = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.match(svg, /width="830"/);
+  });
+});
+
+describe('calculateLayout', () => {
+  it('returns preferred size when no height constraint', () => {
+    const result = calculateLayout(10, 830, null, 56, 8);
+    assert.equal(result.size, 56);
+  });
+
+  it('returns preferred size when all contributors fit within height', () => {
+    const result = calculateLayout(10, 830, 500, 56, 8);
+    assert.equal(result.size, 56);
+  });
+
+  it('shrinks avatar size when contributors do not fit within height', () => {
+    const result = calculateLayout(100, 830, 100, 56, 8);
+    assert.ok(result.size < 56, `Size ${result.size} should be less than preferred size 56`);
+    assert.ok(result.size >= 16, `Size ${result.size} should be at least minimum size 16`);
+    assert.ok(result.finalHeight <= 100, `Height ${result.finalHeight} should be <= 100`);
+  });
+
+  it('returns minimum size when height is very small', () => {
+    const result = calculateLayout(100, 830, 50, 56, 8);
+    assert.equal(result.size, 16);
+  });
+
+  it('handles empty contributor list', () => {
+    const result = calculateLayout(0, 830, null, 56, 8);
+    assert.equal(result.size, 56);
+    assert.equal(result.finalHeight, 88);
+  });
+
+  it('calculates correct number of columns', () => {
+    const result = calculateLayout(20, 830, null, 56, 8);
+    const expectedColumns = Math.floor((830 + 8) / (56 + 8));
+    assert.equal(result.columns, expectedColumns);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #6 - Adjustable block feature implementation

This PR optimizes the SVG output to match GitHub README's max width and adds support for user-defined height constraints with adaptive avatar sizing. **The height and layout options can now be configured directly from the GUI.**

## Changes

### Width Optimization
- Increased default width from 720px to 830px to better match GitHub README's maximum width

### Height Parameter
- Added optional `height` parameter that allows users to set a preferred maximum height in pixels
- Usage: `?height=200` sets max height to 200 pixels
- Supports `auto` or `none` values to explicitly disable height constraints
- Maximum height limited to 4000px

### Adaptive Avatar Sizing
- When height is constrained and avatars don't fit at the preferred size, the system automatically shrinks them
- Uses binary search algorithm to find the optimal avatar size that fits all contributors
- Minimum avatar size is 16px to maintain readability
- If the constraint is too restrictive, avatars will be rendered at minimum size

### GUI Layout Controls
Added a new "Layout options" fieldset in the showcase page with inputs for:
- **Width (px)**: 160-1600, default 830
- **Max height (px)**: 16-4000, auto by default  
- **Avatar size (px)**: 16-128, default 56
- **Gap (px)**: 0-48, default 8

Includes responsive design (4 columns on desktop, 2 on mobile) and helpful hint text.

### API Changes
- `height`: New optional parameter (integer, 16-4000px, or `auto`/`none`)
- `width`: Default changed from 720 to 830
- `size`: Minimum reduced from 24px to 16px to allow more contributors in constrained spaces

## Examples

```markdown
<!-- Default behavior (auto height, 830px width) -->
![Contributors](https://your-domain/api/svg?repo=owner/repo)

<!-- Fixed height of 200px -->
![Contributors](https://your-domain/api/svg?repo=owner/repo&height=200)

<!-- Custom width and height -->
![Contributors](https://your-domain/api/svg?repo=owner/repo&width=600&height=150)
```

## Testing

- Added unit tests for `calculateLayout` function covering:
  - No height constraint (uses preferred size)
  - Contributors fit within height constraint
  - Avatar shrinking when contributors don't fit
  - Minimum size enforcement
  - Empty contributor list handling
  - Column calculation
- Added integration tests for SVG route with height parameter

All tests pass: `npm test` ✅
TypeScript compiles without errors: `npm run typecheck` ✅

---

*This PR was created by an AI assistant (OpenHands) on behalf of the user.*