### PR TITLE
feat: add animated ticker mode for SVG contributor showcase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,5 @@
 - Contributor routes now fetch and render all contributors by default; `limit` is optional and can be omitted or set to `all` for unlimited results.
 - Tests use Node's built-in runner via `tsx --test`; the main route coverage lives in `tests/showcase-routes.test.ts`.
 - `GITHUB_TOKEN` is optional for public repos but recommended to avoid rate limits in local and Vercel environments.
+- SVG endpoint supports `animate=true` for animated ticker mode with CSS keyframe animations; alternating rows scroll horizontally in opposite directions.
+- Animation options: `speed` (px/sec, default 30), `rows` (number of rows, default 3).

--- a/README.md
+++ b/README.md
@@ -65,12 +65,31 @@ Supported query parameters:
 - `width`: optional SVG width, default `720`
 - `size`: optional avatar size, default `56`
 - `gap`: optional gap between avatars, default `8`
+- `animate`: optional; set to `true` to enable animated ticker mode
+- `speed`: optional animation speed in pixels per second, default `30` (only applies when `animate=true`)
+- `rows`: optional number of rows for animated ticker, default `3` (only applies when `animate=true`)
 
-Example:
+Example (static):
 
 ```md
 ![Contributors](https://your-deployment.vercel.app/api/svg?repo=OpenHands/OpenHands&exclude=dependabot,renovate)
 ```
+
+Example (animated ticker):
+
+```md
+![Contributors](https://your-deployment.vercel.app/api/svg?repo=OpenHands/OpenHands&animate=true&rows=4&speed=40)
+```
+
+### Animated Ticker Mode
+
+When `animate=true` is set, the SVG renders as a horizontal scrolling ticker with CSS animations:
+
+- Contributors are distributed across multiple rows (default: 3)
+- Each row scrolls horizontally in alternating directions
+- The animation loops infinitely and seamlessly
+- Works in browsers, GitHub READMEs, and anywhere SVGs with CSS are supported
+- No JavaScript required - pure CSS animations embedded in the SVG
 
 ## API routes
 

--- a/app/api/svg/route.ts
+++ b/app/api/svg/route.ts
@@ -49,6 +49,9 @@ export async function GET(request: Request) {
       width: query.width,
       size: query.size,
       gap: query.gap,
+      animate: query.animate,
+      speed: query.speed,
+      rows: query.rows,
     });
 
     return svgResponse(svg);

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -4,6 +4,8 @@ const DEFAULT_REPO = 'OpenHands/OpenHands';
 const DEFAULT_WIDTH = 720;
 const DEFAULT_SIZE = 56;
 const DEFAULT_GAP = 8;
+const DEFAULT_SPEED = 30;
+const DEFAULT_ROWS = 3;
 const MAX_LIMIT = 100000;
 
 type SearchParamReader = {
@@ -82,6 +84,9 @@ export function parseShowcaseQuery(searchParams: SearchParamReader): ShowcaseQue
     width: parseInteger(searchParams.get('width'), DEFAULT_WIDTH, 160, 1600),
     size: parseInteger(searchParams.get('size'), DEFAULT_SIZE, 24, 128),
     gap: parseInteger(searchParams.get('gap'), DEFAULT_GAP, 0, 48),
+    animate: parseBoolean(searchParams.get('animate'), false),
+    speed: parseInteger(searchParams.get('speed'), DEFAULT_SPEED, 5, 100),
+    rows: parseInteger(searchParams.get('rows'), DEFAULT_ROWS, 1, 10),
   };
 }
 

--- a/lib/svg.ts
+++ b/lib/svg.ts
@@ -33,26 +33,14 @@ async function inlineAvatar(avatarUrl: string, size: number): Promise<string> {
   }
 }
 
-export async function buildContributorSvg(
+function buildStaticSvg(
   contributors: Contributor[],
+  avatars: string[],
   options: SvgLayoutOptions,
-): Promise<string> {
-  if (contributors.length === 0) {
-    return `<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="${options.width}" height="88" viewBox="0 0 ${options.width} 88" role="img" aria-labelledby="title desc">
-  <title id="title">No contributors available for ${escapeXml(options.repoSlug)}</title>
-  <desc id="desc">No contributors were returned after applying the selected filters.</desc>
-  <rect width="100%" height="100%" fill="transparent"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" fill="#6b7280">
-    No contributors matched the current filters.
-  </text>
-</svg>`;
-  }
-
+): string {
   const columns = Math.max(1, Math.floor((options.width + options.gap) / (options.size + options.gap)));
   const rows = Math.ceil(contributors.length / columns);
   const height = rows * options.size + Math.max(0, rows - 1) * options.gap;
-  const avatars = await Promise.all(contributors.map((contributor) => inlineAvatar(contributor.avatarUrl, options.size)));
 
   const content = contributors
     .map((contributor, index) => {
@@ -81,4 +69,133 @@ export async function buildContributorSvg(
   <rect width="100%" height="100%" fill="transparent"/>
 ${content}
 </svg>`;
+}
+
+function buildAnimatedSvg(
+  contributors: Contributor[],
+  avatars: string[],
+  options: SvgLayoutOptions,
+): string {
+  const numRows = options.rows ?? 3;
+  const speed = options.speed ?? 30;
+  const rowHeight = options.size + options.gap;
+  const height = numRows * options.size + Math.max(0, numRows - 1) * options.gap;
+
+  // Distribute contributors across rows
+  const rowContributors: Contributor[][] = Array.from({ length: numRows }, () => []);
+  const rowAvatars: string[][] = Array.from({ length: numRows }, () => []);
+
+  contributors.forEach((contributor, index) => {
+    const rowIndex = index % numRows;
+    rowContributors[rowIndex].push(contributor);
+    rowAvatars[rowIndex].push(avatars[index]);
+  });
+
+  // Calculate animation duration based on content width and speed
+  const calculateRowWidth = (count: number) => count * (options.size + options.gap);
+
+  let rowsContent = '';
+  let defs = '';
+
+  for (let rowIndex = 0; rowIndex < numRows; rowIndex++) {
+    const rowItems = rowContributors[rowIndex];
+    const rowItemAvatars = rowAvatars[rowIndex];
+
+    if (rowItems.length === 0) continue;
+
+    const rowWidth = calculateRowWidth(rowItems.length);
+    const y = rowIndex * rowHeight;
+    const direction = rowIndex % 2 === 0 ? 1 : -1; // Alternate directions
+    const duration = rowWidth / speed; // Duration based on content width and speed
+
+    // Build clip paths for this row
+    rowItems.forEach((_, itemIndex) => {
+      const globalIndex = rowIndex * 10000 + itemIndex;
+      const clipId = `clip-${globalIndex}`;
+      const x = itemIndex * (options.size + options.gap);
+
+      defs += `
+    <clipPath id="${clipId}">
+      <circle cx="${x + options.size / 2}" cy="${options.size / 2}" r="${options.size / 2}" />
+    </clipPath>`;
+    });
+
+    // Build avatars for this row (duplicated for seamless loop)
+    let rowAvatarContent = '';
+    for (let copy = 0; copy < 2; copy++) {
+      rowItems.forEach((contributor, itemIndex) => {
+        const globalIndex = rowIndex * 10000 + copy * 1000 + itemIndex;
+        const clipId = `clip-${rowIndex * 10000 + itemIndex}`;
+        const x = (copy * rowItems.length + itemIndex) * (options.size + options.gap);
+        const label = `${contributor.login} · ${contributor.contributions} contribution${contributor.contributions === 1 ? '' : 's'}`;
+
+        rowAvatarContent += `
+      <g>
+        <title>${escapeXml(label)}</title>
+        <clipPath id="clip-copy-${globalIndex}">
+          <circle cx="${x + options.size / 2}" cy="${options.size / 2}" r="${options.size / 2}" />
+        </clipPath>
+        <image href="${rowItemAvatars[itemIndex]}" x="${x}" y="0" width="${options.size}" height="${options.size}" clip-path="url(#clip-copy-${globalIndex})" preserveAspectRatio="xMidYMid slice" />
+      </g>`;
+      });
+    }
+
+    const animationName = `scroll-row-${rowIndex}`;
+    const totalWidth = rowWidth * 2;
+    const translateStart = direction === 1 ? 0 : -rowWidth;
+    const translateEnd = direction === 1 ? -rowWidth : 0;
+
+    rowsContent += `
+  <g transform="translate(0, ${y})">
+    <g class="${animationName}">
+      ${rowAvatarContent}
+    </g>
+  </g>`;
+
+    defs += `
+  <style>
+    .${animationName} {
+      animation: ${animationName} ${duration}s linear infinite;
+    }
+    @keyframes ${animationName} {
+      from { transform: translateX(${translateStart}px); }
+      to { transform: translateX(${translateEnd}px); }
+    }
+  </style>`;
+  }
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${options.width}" height="${height}" viewBox="0 0 ${options.width} ${height}" role="img" aria-labelledby="title desc">
+  <title id="title">Contributors for ${escapeXml(options.repoSlug)} (animated ticker)</title>
+  <desc id="desc">An animated ticker showing contributor avatars scrolling horizontally in multiple rows.</desc>
+  <defs>${defs}
+  </defs>
+  <rect width="100%" height="100%" fill="transparent"/>
+${rowsContent}
+</svg>`;
+}
+
+export async function buildContributorSvg(
+  contributors: Contributor[],
+  options: SvgLayoutOptions,
+): Promise<string> {
+  if (contributors.length === 0) {
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${options.width}" height="88" viewBox="0 0 ${options.width} 88" role="img" aria-labelledby="title desc">
+  <title id="title">No contributors available for ${escapeXml(options.repoSlug)}</title>
+  <desc id="desc">No contributors were returned after applying the selected filters.</desc>
+  <rect width="100%" height="100%" fill="transparent"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" fill="#6b7280">
+    No contributors matched the current filters.
+  </text>
+</svg>`;
+  }
+
+  const avatars = await Promise.all(contributors.map((contributor) => inlineAvatar(contributor.avatarUrl, options.size)));
+
+  if (options.animate) {
+    return buildAnimatedSvg(contributors, avatars, options);
+  }
+
+  return buildStaticSvg(contributors, avatars, options);
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -28,6 +28,9 @@ export type ShowcaseQuery = {
   width: number;
   size: number;
   gap: number;
+  animate: boolean;
+  speed: number;
+  rows: number;
 };
 
 export type SvgLayoutOptions = {
@@ -35,4 +38,7 @@ export type SvgLayoutOptions = {
   width: number;
   size: number;
   gap: number;
+  animate?: boolean;
+  speed?: number;
+  rows?: number;
 };

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tests/showcase-routes.test.ts
+++ b/tests/showcase-routes.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
 import { GET as getContributors } from '@/app/api/contributors/route';
 import { GET as getSvg } from '@/app/api/svg/route';
+import { parseShowcaseQuery } from '@/lib/query';
 
 type RawContributor = {
   login: string;
@@ -110,5 +111,52 @@ describe('showcase routes', () => {
     assert.match(svg, /user-205 · 205 contributions/);
     assert.equal(requests.getGithubRequests(), 3);
     assert.equal(requests.getAvatarRequests(), 205);
+  });
+
+  it('renders animated SVG with CSS keyframes when animate=true', async () => {
+    const contributors = Array.from({ length: 30 }, (_, index) => createContributor(index + 1));
+    installFetchMock(contributors);
+
+    const response = await getSvg(new Request('http://localhost/api/svg?repo=owner/repo&animate=true&rows=3'));
+    const svg = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.match(svg, /animated ticker/);
+    assert.match(svg, /@keyframes scroll-row-0/);
+    assert.match(svg, /@keyframes scroll-row-1/);
+    assert.match(svg, /@keyframes scroll-row-2/);
+    assert.match(svg, /animation:.*linear infinite/);
+    assert.match(svg, /translateX/);
+  });
+
+  it('parses animate query parameter correctly', () => {
+    const params = new URLSearchParams('repo=owner/repo&animate=true&speed=50&rows=5');
+    const query = parseShowcaseQuery(params);
+
+    assert.equal(query.animate, true);
+    assert.equal(query.speed, 50);
+    assert.equal(query.rows, 5);
+  });
+
+  it('defaults animate to false when not specified', () => {
+    const params = new URLSearchParams('repo=owner/repo');
+    const query = parseShowcaseQuery(params);
+
+    assert.equal(query.animate, false);
+    assert.equal(query.speed, 30);
+    assert.equal(query.rows, 3);
+  });
+
+  it('renders static SVG without animation keyframes when animate is not set', async () => {
+    const contributors = Array.from({ length: 10 }, (_, index) => createContributor(index + 1));
+    installFetchMock(contributors);
+
+    const response = await getSvg(new Request('http://localhost/api/svg?repo=owner/repo'));
+    const svg = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.doesNotMatch(svg, /@keyframes/);
+    assert.doesNotMatch(svg, /animation:/);
+    assert.doesNotMatch(svg, /animated ticker/);
   });
 });


### PR DESCRIPTION
## Summary

This PR implements an animated ticker/marquee mode for the SVG contributor showcase. When `animate=true` is set, the SVG renders as a horizontal scrolling ticker with pure CSS animations.

Fixes #7

## Changes

### New Query Parameters

| Parameter | Description | Default | Range |
|-----------|-------------|---------|-------|
| `animate` | Enable animated ticker mode | `false` | `true`/`false` |
| `speed` | Animation speed in pixels per second | `30` | `5-100` |
| `rows` | Number of rows for ticker layout | `3` | `1-10` |

### Features

- **Pure CSS Animations**: Uses CSS `@keyframes` with `translateX` for smooth, infinite scrolling
- **Alternating Directions**: Each row scrolls in opposite directions for visual interest
- **Seamless Looping**: Contributors are duplicated in each row for seamless infinite scroll
- **No JavaScript Required**: Works anywhere SVGs with CSS are supported (browsers, GitHub READMEs, etc.)
- **Customizable**: Speed and number of rows are configurable

### Example Usage

```md
![Contributors](https://your-deployment.vercel.app/api/svg?repo=OpenHands/OpenHands&animate=true&rows=4&speed=40)
```

## Technical Details

The implementation:
1. Distributes contributors across the specified number of rows (round-robin)
2. Duplicates each row's content for seamless looping
3. Generates CSS `@keyframes` for each row with alternating `translateX` directions
4. Calculates animation duration based on row width and speed

## Files Changed

- `lib/types.ts` - Added animation options to types
- `lib/query.ts` - Added parsing for `animate`, `speed`, `rows` parameters
- `lib/svg.ts` - Added `buildAnimatedSvg` function with CSS keyframe animations
- `app/api/svg/route.ts` - Pass animation options to SVG builder
- `tests/showcase-routes.test.ts` - Added tests for animated SVG feature
- `README.md` - Documented new parameters and animated ticker mode
- `AGENTS.md` - Updated repository memory

## Testing

All tests pass, including new tests for:
- Animated SVG rendering with CSS keyframes
- Query parameter parsing for animation options
- Static SVG rendering (no animation when `animate` is not set)

---

*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

@jamiechicago312 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/63941dff-618d-43ae-9147-efd077217a01)