### PR TITLE
Add manual contributor excludes with lightweight suggestions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,4 @@
 - Contributor routes now fetch and render all contributors by default; `limit` is optional and can be omitted or set to `all` for unlimited results.
 - Tests use Node's built-in runner via `tsx --test`; the main route coverage lives in `tests/showcase-routes.test.ts`.
 - `GITHUB_TOKEN` is optional for public repos but recommended to avoid rate limits in local and Vercel environments.
+- Showcase UI now defaults to showing every contributor; manual exclusions are entered via text input with lightweight client-side suggestions from the loaded contributor list.

--- a/app/globals.css
+++ b/app/globals.css
@@ -134,6 +134,63 @@ button {
   color: #64748b;
 }
 
+.field-hint {
+  margin: -2px 0 0;
+  color: #94a3b8;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.suggestion-list {
+  display: grid;
+  gap: 8px;
+}
+
+.suggestion-button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: 12px 14px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.56);
+  color: #e2e8f0;
+  text-align: left;
+}
+
+.suggestion-button:hover {
+  background: rgba(30, 41, 59, 0.88);
+}
+
+.suggestion-button span {
+  color: #f8fafc;
+}
+
+.suggestion-meta {
+  color: #94a3b8;
+  font-size: 0.82rem;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tag-button {
+  border: 1px solid rgba(96, 165, 250, 0.24);
+  border-radius: 999px;
+  padding: 8px 12px;
+  background: rgba(59, 130, 246, 0.12);
+  color: #bfdbfe;
+}
+
+.tag-button:hover {
+  background: rgba(59, 130, 246, 0.2);
+}
+
 .checkbox-row {
   display: flex;
   align-items: center;

--- a/app/showcase-page.tsx
+++ b/app/showcase-page.tsx
@@ -26,7 +26,6 @@ type ContributorResponse = {
 
 type FormState = {
   repoInput: string;
-  excludeBots: boolean;
   exclude: string;
   width: string;
   height: string;
@@ -36,7 +35,6 @@ type FormState = {
 
 const DEFAULT_STATE: FormState = {
   repoInput: 'OpenHands/OpenHands',
-  excludeBots: true,
   exclude: '',
   width: '830',
   height: '',
@@ -53,13 +51,21 @@ function parseOptionalInt(value: string | null, fallback: string): string {
 function readFormState(searchParams: URLSearchParams): FormState {
   return {
     repoInput: searchParams.get('repo')?.trim() || DEFAULT_STATE.repoInput,
-    excludeBots: searchParams.get('excludeBots') !== 'false',
     exclude: searchParams.get('exclude') || '',
     width: parseOptionalInt(searchParams.get('width'), DEFAULT_STATE.width),
     height: searchParams.get('height') || '',
     size: parseOptionalInt(searchParams.get('size'), DEFAULT_STATE.size),
     gap: parseOptionalInt(searchParams.get('gap'), DEFAULT_STATE.gap),
   };
+}
+
+function getActiveExcludeToken(value: string): string {
+  return value.split(',').at(-1)?.trim().toLowerCase() ?? '';
+}
+
+function replaceActiveExcludeToken(value: string, login: string): string {
+  const existing = parseExcludeList(value.split(',').slice(0, -1).join(','));
+  return `${[...existing, login.toLowerCase()].join(', ')}, `;
 }
 
 export default function HomePage() {
@@ -73,9 +79,26 @@ export default function HomePage() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [copyMessage, setCopyMessage] = useState('');
+  const [excludeInputFocused, setExcludeInputFocused] = useState(false);
 
   const searchParamString = searchParams.toString();
   const currentState = useMemo(() => readFormState(new URLSearchParams(searchParamString)), [searchParamString]);
+  const excludedLogins = useMemo(() => parseExcludeList(formState.exclude), [formState.exclude]);
+  const activeExcludeToken = useMemo(() => getActiveExcludeToken(formState.exclude), [formState.exclude]);
+  const contributorSuggestions = useMemo(() => {
+    if (!data || !activeExcludeToken) {
+      return [];
+    }
+
+    const excluded = new Set(excludedLogins);
+
+    return data.contributors
+      .filter((contributor) => {
+        const login = contributor.login.toLowerCase();
+        return !excluded.has(login) && login.includes(activeExcludeToken);
+      })
+      .slice(0, 8);
+  }, [activeExcludeToken, data, excludedLogins]);
 
   useEffect(() => {
     setOrigin(window.location.origin);
@@ -89,7 +112,7 @@ export default function HomePage() {
   useEffect(() => {
     const params = buildQueryString({
       repoInput: appliedState.repoInput,
-      excludeBots: appliedState.excludeBots,
+      excludeBots: false,
       excludeLogins: parseExcludeList(appliedState.exclude),
     });
 
@@ -141,7 +164,7 @@ export default function HomePage() {
     () =>
       buildQueryString({
         repoInput: appliedState.repoInput,
-        excludeBots: appliedState.excludeBots,
+        excludeBots: false,
         excludeLogins: parseExcludeList(appliedState.exclude),
         width: appliedState.width ? Number.parseInt(appliedState.width, 10) : null,
         height: appliedState.height ? Number.parseInt(appliedState.height, 10) : null,
@@ -166,13 +189,28 @@ export default function HomePage() {
     }
   }
 
+  function applyExcludeSuggestion(login: string) {
+    setFormState((current) => ({
+      ...current,
+      exclude: replaceActiveExcludeToken(current.exclude, login),
+    }));
+  }
+
+  function removeExcludedLogin(login: string) {
+    setFormState((current) => ({
+      ...current,
+      exclude: parseExcludeList(current.exclude)
+        .filter((item) => item !== login.toLowerCase())
+        .join(', '),
+    }));
+  }
+
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
     const nextState: FormState = {
       repoInput: formState.repoInput.trim() || DEFAULT_STATE.repoInput,
-      excludeBots: formState.excludeBots,
-      exclude: formState.exclude,
+      exclude: excludedLogins.join(', '),
       width: formState.width || DEFAULT_STATE.width,
       height: formState.height,
       size: formState.size || DEFAULT_STATE.size,
@@ -181,7 +219,7 @@ export default function HomePage() {
 
     const params = buildQueryString({
       repoInput: nextState.repoInput,
-      excludeBots: nextState.excludeBots,
+      excludeBots: false,
       excludeLogins: parseExcludeList(nextState.exclude),
       width: nextState.width ? Number.parseInt(nextState.width, 10) : null,
       height: nextState.height ? Number.parseInt(nextState.height, 10) : null,
@@ -200,7 +238,7 @@ export default function HomePage() {
           <span className="eyebrow">README-safe contributor collage</span>
           <h1>Turn any public GitHub repository into a transparent avatar wall.</h1>
           <p>
-            Paste a repository, filter bots, preview the SVG, and copy a Markdown-ready image URL for your GitHub README.
+            Paste a repository, optionally hide specific logins, preview the SVG, and copy a Markdown-ready image URL for your GitHub README.
           </p>
         </div>
 
@@ -215,23 +253,44 @@ export default function HomePage() {
             />
           </label>
 
-          <label className="field-group checkbox-row">
-            <input
-              type="checkbox"
-              checked={formState.excludeBots}
-              onChange={(event) => setFormState((current) => ({ ...current, excludeBots: event.target.checked }))}
-            />
-            <span>Exclude bots automatically</span>
-          </label>
-
-          <label className="field-group">
-            <span>Manual excludes</span>
+          <label className="field-group field-span-2">
+            <span>Exclude contributors</span>
             <input
               name="exclude"
-              placeholder="dependabot, renovate"
+              placeholder="dependabot[bot], renovate[bot]"
+              autoComplete="off"
+              spellCheck={false}
               value={formState.exclude}
+              onFocus={() => setExcludeInputFocused(true)}
+              onBlur={() => window.setTimeout(() => setExcludeInputFocused(false), 120)}
               onChange={(event) => setFormState((current) => ({ ...current, exclude: event.target.value }))}
             />
+            <p className="field-hint">Start typing a login to get lightweight suggestions from the loaded contributor list.</p>
+            {excludeInputFocused && contributorSuggestions.length > 0 ? (
+              <div className="suggestion-list" role="listbox" aria-label="Contributor suggestions">
+                {contributorSuggestions.map((contributor) => (
+                  <button
+                    key={contributor.login}
+                    type="button"
+                    className="suggestion-button"
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => applyExcludeSuggestion(contributor.login)}
+                  >
+                    <span>{contributor.login}</span>
+                    <small className="suggestion-meta">{contributor.contributions} contributions</small>
+                  </button>
+                ))}
+              </div>
+            ) : null}
+            {excludedLogins.length > 0 ? (
+              <div className="tag-list" aria-label="Excluded contributors">
+                {excludedLogins.map((login) => (
+                  <button key={login} type="button" className="tag-button" onClick={() => removeExcludedLogin(login)}>
+                    {login} ×
+                  </button>
+                ))}
+              </div>
+            ) : null}
           </label>
 
           <fieldset className="field-group field-span-2 layout-fieldset">
@@ -353,7 +412,7 @@ export default function HomePage() {
                 </div>
                 <div>
                   <strong>{data.stats.filteredOut}</strong>
-                  <span>filtered out</span>
+                  <span>excluded</span>
                 </div>
               </div>
               <p className="muted">

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -92,7 +92,7 @@ export function parseExcludeList(value: string | null): string[] {
 export function parseShowcaseQuery(searchParams: SearchParamReader): ShowcaseQuery {
   return {
     repoInput: searchParams.get('repo')?.trim() || DEFAULT_REPO,
-    excludeBots: parseBoolean(searchParams.get('excludeBots'), true),
+    excludeBots: parseBoolean(searchParams.get('excludeBots'), false),
     excludeLogins: parseExcludeList(searchParams.get('exclude')),
     limit: parseLimit(searchParams.get('limit')),
     width: parseInteger(searchParams.get('width'), DEFAULT_WIDTH, 160, 1600),
@@ -113,8 +113,8 @@ export function buildQueryString(query: BuildQueryOptions): string {
   const params = new URLSearchParams();
   params.set('repo', query.repoInput.trim() || DEFAULT_REPO);
 
-  if (!query.excludeBots) {
-    params.set('excludeBots', 'false');
+  if (query.excludeBots) {
+    params.set('excludeBots', 'true');
   }
 
   if (query.excludeLogins.length > 0) {

--- a/tests/showcase-routes.test.ts
+++ b/tests/showcase-routes.test.ts
@@ -9,7 +9,7 @@ type RawContributor = {
   avatar_url: string;
   html_url: string;
   contributions: number;
-  type: 'User';
+  type: 'User' | 'Bot';
 };
 
 const originalFetch = globalThis.fetch;
@@ -21,6 +21,16 @@ function createContributor(index: number): RawContributor {
     html_url: `https://github.com/user-${index}`,
     contributions: index,
     type: 'User',
+  };
+}
+
+function createBotContributor(login = 'dependabot[bot]', contributions = 99): RawContributor {
+  return {
+    login,
+    avatar_url: `https://avatars.example.com/${login}.png`,
+    html_url: `https://github.com/apps/${login}`,
+    contributions,
+    type: 'Bot',
   };
 }
 
@@ -79,6 +89,49 @@ describe('showcase routes', () => {
     assert.equal(payload.contributors.length, 205);
     assert.equal(payload.contributors.at(-1)?.login, 'user-205');
     assert.equal(requests.getGithubRequests(), 3);
+  });
+
+  it('does not exclude bot accounts by default', async () => {
+    const contributors = [createContributor(1), createBotContributor(), createContributor(2)];
+    installFetchMock(contributors);
+
+    const response = await getContributors(new Request('http://localhost/api/contributors?repo=owner/repo'));
+    const payload = (await response.json()) as {
+      stats: { fetched: number; returned: number; filteredOut: number };
+      contributors: Array<{ login: string }>;
+      options: { excludeBots: boolean };
+    };
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.options.excludeBots, false);
+    assert.equal(payload.stats.fetched, 3);
+    assert.equal(payload.stats.returned, 3);
+    assert.equal(payload.stats.filteredOut, 0);
+    assert.deepEqual(
+      payload.contributors.map((contributor) => contributor.login),
+      ['user-1', 'dependabot[bot]', 'user-2'],
+    );
+  });
+
+  it('honors manual excludes from the query string', async () => {
+    const contributors = [createContributor(1), createBotContributor(), createContributor(2)];
+    installFetchMock(contributors);
+
+    const response = await getContributors(
+      new Request('http://localhost/api/contributors?repo=owner/repo&exclude=dependabot%5Bbot%5D,user-2'),
+    );
+    const payload = (await response.json()) as {
+      stats: { returned: number; filteredOut: number };
+      contributors: Array<{ login: string }>;
+    };
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.stats.returned, 1);
+    assert.equal(payload.stats.filteredOut, 2);
+    assert.deepEqual(
+      payload.contributors.map((contributor) => contributor.login),
+      ['user-1'],
+    );
   });
 
   it('still honors an explicit numeric limit', async () => {


### PR DESCRIPTION
## Summary
- stop automatically excluding bot accounts by default
- add a manual exclude input with lightweight contributor suggestions from the loaded list
- cover the new default and manual exclude behavior in route tests

## Validation
- npm test
- npm run typecheck
- npm run build

_This PR was created by an AI assistant (OpenHands) on behalf of the user._