### PR TITLE
Auto-exclude dependabot contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,4 +8,4 @@
 - Contributor routes now fetch and render all contributors by default; `limit` is optional and can be omitted or set to `all` for unlimited results.
 - Tests use Node's built-in runner via `tsx --test`; the main route coverage lives in `tests/showcase-routes.test.ts`.
 - `GITHUB_TOKEN` is optional for public repos but recommended to avoid rate limits in local and Vercel environments.
-- Showcase UI now defaults to showing every contributor; manual exclusions are entered via text input with lightweight client-side suggestions from the loaded contributor list.
+- Showcase UI now defaults to showing every contributor except dependabot-style accounts, which are auto-excluded; other manual exclusions are entered via text input with lightweight client-side suggestions from the loaded contributor list.

--- a/app/showcase-page.tsx
+++ b/app/showcase-page.tsx
@@ -265,7 +265,7 @@ export default function HomePage() {
               onBlur={() => window.setTimeout(() => setExcludeInputFocused(false), 120)}
               onChange={(event) => setFormState((current) => ({ ...current, exclude: event.target.value }))}
             />
-            <p className="field-hint">Start typing a login to get lightweight suggestions from the loaded contributor list.</p>
+            <p className="field-hint">Dependabot is hidden automatically. Start typing another login to get lightweight suggestions from the loaded contributor list.</p>
             {excludeInputFocused && contributorSuggestions.length > 0 ? (
               <div className="suggestion-list" role="listbox" aria-label="Contributor suggestions">
                 {contributorSuggestions.map((contributor) => (

--- a/lib/contributors.ts
+++ b/lib/contributors.ts
@@ -1,5 +1,9 @@
 import type { Contributor, RawGitHubContributor } from '@/lib/types';
 
+function isDependabotLike(login: string): boolean {
+  return login.toLowerCase().startsWith('dependabot');
+}
+
 function isLikelyBot(login: string, type?: string): boolean {
   if (type === 'Bot') {
     return true;
@@ -9,8 +13,7 @@ function isLikelyBot(login: string, type?: string): boolean {
 
   return (
     normalized.endsWith('[bot]') ||
-    normalized === 'dependabot' ||
-    normalized.startsWith('dependabot') ||
+    isDependabotLike(login) ||
     normalized === 'renovate' ||
     normalized === 'github-actions' ||
     /(?:^|[-_])bot(?:$|[-_])/i.test(normalized)
@@ -41,7 +44,7 @@ export function filterContributors(
   const excluded = new Set(options.excludeLogins.map((login) => login.toLowerCase()));
 
   return contributors.filter((contributor) => {
-    if (excluded.has(contributor.login.toLowerCase())) {
+    if (isDependabotLike(contributor.login) || excluded.has(contributor.login.toLowerCase())) {
       return false;
     }
 

--- a/tests/showcase-routes.test.ts
+++ b/tests/showcase-routes.test.ts
@@ -24,7 +24,7 @@ function createContributor(index: number): RawContributor {
   };
 }
 
-function createBotContributor(login = 'dependabot[bot]', contributions = 99): RawContributor {
+function createBotContributor(login = 'renovate[bot]', contributions = 99): RawContributor {
   return {
     login,
     avatar_url: `https://avatars.example.com/${login}.png`,
@@ -32,6 +32,10 @@ function createBotContributor(login = 'dependabot[bot]', contributions = 99): Ra
     contributions,
     type: 'Bot',
   };
+}
+
+function createDependabotContributor(login = 'dependabot[bot]', contributions = 99): RawContributor {
+  return createBotContributor(login, contributions);
 }
 
 function installFetchMock(contributors: RawContributor[]) {
@@ -91,7 +95,29 @@ describe('showcase routes', () => {
     assert.equal(requests.getGithubRequests(), 3);
   });
 
-  it('does not exclude bot accounts by default', async () => {
+  it('auto-excludes dependabot accounts by default', async () => {
+    const contributors = [createContributor(1), createDependabotContributor(), createContributor(2)];
+    installFetchMock(contributors);
+
+    const response = await getContributors(new Request('http://localhost/api/contributors?repo=owner/repo'));
+    const payload = (await response.json()) as {
+      stats: { fetched: number; returned: number; filteredOut: number };
+      contributors: Array<{ login: string }>;
+      options: { excludeBots: boolean };
+    };
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.options.excludeBots, false);
+    assert.equal(payload.stats.fetched, 3);
+    assert.equal(payload.stats.returned, 2);
+    assert.equal(payload.stats.filteredOut, 1);
+    assert.deepEqual(
+      payload.contributors.map((contributor) => contributor.login),
+      ['user-1', 'user-2'],
+    );
+  });
+
+  it('does not exclude other bot accounts by default', async () => {
     const contributors = [createContributor(1), createBotContributor(), createContributor(2)];
     installFetchMock(contributors);
 
@@ -109,7 +135,7 @@ describe('showcase routes', () => {
     assert.equal(payload.stats.filteredOut, 0);
     assert.deepEqual(
       payload.contributors.map((contributor) => contributor.login),
-      ['user-1', 'dependabot[bot]', 'user-2'],
+      ['user-1', 'renovate[bot]', 'user-2'],
     );
   });
 
@@ -118,7 +144,7 @@ describe('showcase routes', () => {
     installFetchMock(contributors);
 
     const response = await getContributors(
-      new Request('http://localhost/api/contributors?repo=owner/repo&exclude=dependabot%5Bbot%5D,user-2'),
+      new Request('http://localhost/api/contributors?repo=owner/repo&exclude=renovate%5Bbot%5D,user-2'),
     );
     const payload = (await response.json()) as {
       stats: { returned: number; filteredOut: number };


### PR DESCRIPTION
## Summary
- automatically hide dependabot-style contributor accounts
- keep all other bot accounts manually controllable through the existing exclude input
- update route tests to cover the new default behavior

## Validation
- npm test
- npm run typecheck
- npm run build

_This PR was created by an AI assistant (OpenHands) on behalf of the user._