### PR TITLE
Load anonymous GitHub contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,4 @@
 - Tests use Node's built-in runner via `tsx --test`; the main route coverage lives in `tests/showcase-routes.test.ts`.
 - `GITHUB_TOKEN` is optional for public repos but recommended to avoid rate limits in local and Vercel environments.
 - Showcase UI now defaults to showing every contributor except dependabot-style accounts, which are auto-excluded; other manual exclusions are entered via text input with lightweight client-side suggestions from the loaded contributor list.
+- GitHub contributor fetching now requests `anon=1` so large repos can include anonymous commit authors beyond the named-account contributor list; anonymous contributors get generated placeholder avatars and no profile link.

--- a/app/showcase-page.tsx
+++ b/app/showcase-page.tsx
@@ -18,7 +18,7 @@ type ContributorResponse = {
   contributors: Array<{
     login: string;
     avatarUrl: string;
-    profileUrl: string;
+    profileUrl: string | null;
     contributions: number;
   }>;
   error?: string;
@@ -419,11 +419,23 @@ export default function HomePage() {
                 Showing contributors for <strong>{data.repo.slug}</strong>.
               </p>
               <div className="avatar-list" aria-label="Contributor list">
-                {data.contributors.slice(0, 18).map((contributor) => (
-                  <a key={contributor.login} href={contributor.profileUrl} target="_blank" rel="noreferrer" title={contributor.login}>
-                    <img src={contributor.avatarUrl} alt={contributor.login} width={36} height={36} />
-                  </a>
-                ))}
+                {data.contributors.slice(0, 18).map((contributor) => {
+                  const avatar = <img src={contributor.avatarUrl} alt={contributor.login} width={36} height={36} />;
+
+                  if (!contributor.profileUrl) {
+                    return (
+                      <span key={contributor.login} title={`${contributor.login} (anonymous contributor)`}>
+                        {avatar}
+                      </span>
+                    );
+                  }
+
+                  return (
+                    <a key={contributor.login} href={contributor.profileUrl} target="_blank" rel="noreferrer" title={contributor.login}>
+                      {avatar}
+                    </a>
+                  );
+                })}
               </div>
             </>
           ) : (

--- a/lib/contributors.ts
+++ b/lib/contributors.ts
@@ -4,6 +4,21 @@ function isDependabotLike(login: string): boolean {
   return login.toLowerCase().startsWith('dependabot');
 }
 
+function buildAnonymousAvatar(label: string): string {
+  const initials = label
+    .split(/[^a-z0-9]+/i)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('') || '?';
+
+  const safeLabel = label.replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+  const hue = Array.from(label).reduce((total, char) => total + char.charCodeAt(0), 0) % 360;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="${safeLabel}"><rect width="64" height="64" rx="32" fill="hsl(${hue} 45% 24%)"/><text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="system-ui, sans-serif" font-size="24" font-weight="700" fill="white">${initials}</text></svg>`;
+
+  return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
+}
+
 function isLikelyBot(login: string, type?: string): boolean {
   if (type === 'Bot') {
     return true;
@@ -20,18 +35,31 @@ function isLikelyBot(login: string, type?: string): boolean {
   );
 }
 
+function normalizeLogin(contributor: RawGitHubContributor, index: number): string {
+  const name = contributor.name?.trim();
+  const emailPrefix = contributor.email?.split('@')[0]?.trim();
+  return contributor.login?.trim() || name || emailPrefix || `anonymous-${index + 1}`;
+}
+
 export function normalizeContributors(rawContributors: RawGitHubContributor[]): Contributor[] {
-  return rawContributors
-    .filter((contributor): contributor is Required<Pick<RawGitHubContributor, 'login' | 'avatar_url' | 'html_url'>> & RawGitHubContributor => {
-      return Boolean(contributor.login && contributor.avatar_url && contributor.html_url);
-    })
-    .map((contributor) => ({
-      login: contributor.login,
-      avatarUrl: contributor.avatar_url,
-      profileUrl: contributor.html_url,
+  const seenLogins = new Map<string, number>();
+
+  return rawContributors.map((contributor, index) => {
+    const baseLogin = normalizeLogin(contributor, index);
+    const normalizedLogin = baseLogin.toLowerCase();
+    const duplicateCount = seenLogins.get(normalizedLogin) ?? 0;
+    seenLogins.set(normalizedLogin, duplicateCount + 1);
+
+    const login = duplicateCount === 0 ? baseLogin : `${baseLogin} (${duplicateCount + 1})`;
+
+    return {
+      login,
+      avatarUrl: contributor.avatar_url?.trim() || buildAnonymousAvatar(login),
+      profileUrl: contributor.html_url?.trim() || null,
       contributions: contributor.contributions ?? 0,
-      isBot: isLikelyBot(contributor.login, contributor.type),
-    }));
+      isBot: isLikelyBot(login, contributor.type),
+    };
+  });
 }
 
 export function filterContributors(

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -29,7 +29,7 @@ export async function fetchGitHubContributors(
 
   for (let page = 1; ; page += 1) {
     const response = await fetch(
-      `${GITHUB_API_BASE_URL}/repos/${owner}/${repo}/contributors?per_page=100&page=${page}`,
+      `${GITHUB_API_BASE_URL}/repos/${owner}/${repo}/contributors?per_page=100&page=${page}&anon=1`,
       {
         headers: buildHeaders(),
         next: { revalidate: 3600 },

--- a/lib/svg.ts
+++ b/lib/svg.ts
@@ -16,6 +16,10 @@ function toDataUri(contentType: string, bytes: ArrayBuffer): string {
 }
 
 async function inlineAvatar(avatarUrl: string, size: number): Promise<string> {
+  if (avatarUrl.startsWith('data:')) {
+    return avatarUrl;
+  }
+
   const sizedUrl = `${avatarUrl}${avatarUrl.includes('?') ? '&' : '?'}s=${Math.max(size * 2, 64)}`;
 
   try {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,12 +4,14 @@ export type RawGitHubContributor = {
   html_url?: string;
   contributions?: number;
   type?: string;
+  name?: string;
+  email?: string;
 };
 
 export type Contributor = {
   login: string;
   avatarUrl: string;
-  profileUrl: string;
+  profileUrl: string | null;
   contributions: number;
   isBot: boolean;
 };

--- a/tests/showcase-routes.test.ts
+++ b/tests/showcase-routes.test.ts
@@ -5,11 +5,13 @@ import { GET as getSvg } from '@/app/api/svg/route';
 import { calculateLayout } from '@/lib/svg';
 
 type RawContributor = {
-  login: string;
-  avatar_url: string;
-  html_url: string;
+  login?: string;
+  avatar_url?: string;
+  html_url?: string;
   contributions: number;
-  type: 'User' | 'Bot';
+  type: 'User' | 'Bot' | 'Anonymous';
+  name?: string;
+  email?: string;
 };
 
 const originalFetch = globalThis.fetch;
@@ -38,8 +40,20 @@ function createDependabotContributor(login = 'dependabot[bot]', contributions = 
   return createBotContributor(login, contributions);
 }
 
+
+function createAnonymousContributor(index: number): RawContributor {
+  return {
+    name: `Anon ${index}`,
+    email: `anon-${index}@example.com`,
+    contributions: index,
+    type: 'Anonymous',
+  };
+}
+
 function installFetchMock(contributors: RawContributor[]) {
-  const pages = [contributors.slice(0, 100), contributors.slice(100, 200), contributors.slice(200)];
+  const pages = Array.from({ length: Math.ceil(contributors.length / 100) }, (_, index) =>
+    contributors.slice(index * 100, (index + 1) * 100),
+  );
   let githubRequests = 0;
   let avatarRequests = 0;
 
@@ -48,6 +62,7 @@ function installFetchMock(contributors: RawContributor[]) {
 
     if (url.origin === 'https://api.github.com') {
       githubRequests += 1;
+      assert.equal(url.searchParams.get('anon'), '1');
       const page = Number(url.searchParams.get('page') ?? '1');
       return Response.json(pages[page - 1] ?? []);
     }
@@ -93,6 +108,42 @@ describe('showcase routes', () => {
     assert.equal(payload.contributors.length, 205);
     assert.equal(payload.contributors.at(-1)?.login, 'user-205');
     assert.equal(requests.getGithubRequests(), 3);
+  });
+
+  it('loads anonymous contributors across pages beyond the named-account limit', async () => {
+    const contributors = [
+      ...Array.from({ length: 359 }, (_, index) => createContributor(index + 1)),
+      ...Array.from({ length: 246 }, (_, index) => createAnonymousContributor(index + 1)),
+    ];
+    const requests = installFetchMock(contributors);
+
+    const response = await getContributors(new Request('http://localhost/api/contributors?repo=owner/repo'));
+    const payload = (await response.json()) as {
+      stats: { fetched: number; returned: number };
+      contributors: Array<{ login: string; profileUrl: string | null; avatarUrl: string }>;
+    };
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.stats.fetched, 605);
+    assert.equal(payload.stats.returned, 605);
+    assert.equal(payload.contributors.length, 605);
+    assert.equal(payload.contributors[359]?.login, 'Anon 1');
+    assert.equal(payload.contributors[359]?.profileUrl, null);
+    assert.match(payload.contributors[359]?.avatarUrl ?? '', /^data:image\/svg\+xml/);
+    assert.equal(requests.getGithubRequests(), 7);
+  });
+
+  it('renders anonymous contributors in the SVG without fetching remote avatars for them', async () => {
+    const contributors = [createContributor(1), createAnonymousContributor(1), createAnonymousContributor(2)];
+    const requests = installFetchMock(contributors);
+
+    const response = await getSvg(new Request('http://localhost/api/svg?repo=owner/repo'));
+    const svg = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.equal((svg.match(/<image /g) ?? []).length, 3);
+    assert.match(svg, /Anon 1 · 1 contribution/);
+    assert.equal(requests.getAvatarRequests(), 1);
   });
 
   it('auto-excludes dependabot accounts by default', async () => {


### PR DESCRIPTION
## Summary
- request GitHub contributors with `anon=1` so large repos include anonymous commit authors
- normalize anonymous contributors with generated placeholder avatars and no broken profile links
- add regression coverage for large multi-page contributor lists and anonymous SVG rendering

## Validation
- npm test
- npm run typecheck
- npm run build

_This PR was created by an AI assistant (OpenHands) on behalf of the user._